### PR TITLE
Fix compatibility error with Chef 13.x [GH-40] 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 CHANGELOG for Android-SDK cookbook
 ==================================
 
+v0.3.1
+------
+
+- Fix compatibility error with Chef 13.x [GH-40] The `Chef::Resource::Script#path`
+  property has been removed in Chef 13.
+
+v0.3.0
+------
+
+- Re-code
+
 v0.2.0 (2015-10-17)
 -------------------
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs Google Android SDK'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/gildegoma/chef-android-sdk/issues'
 source_url 'https://github.com/gildegoma/chef-android-sdk'
-version '0.3.0'
+version '0.3.1'
 
 depends 'java', '~> 1.42'
 depends 'ark', '>= 1.1.0'

--- a/recipes/unix.rb
+++ b/recipes/unix.rb
@@ -136,7 +136,6 @@ unless File.exist?("#{setup_root}/#{node['android-sdk']['name']}/temp")
     script "Install Android SDK component #{sdk_component}" do
       interpreter 'expect'
       environment 'ANDROID_HOME' => android_home
-      path [File.join(android_home, 'tools')]
       user node['android-sdk']['owner']
       group node['android-sdk']['group']
       # TODO: use --force or not?
@@ -167,7 +166,6 @@ unless File.exist?("#{setup_root}/#{node['android-sdk']['name']}/temp")
     script "Install Android package #{package}" do
       interpreter 'expect'
       environment 'ANDROID_HOME' => android_home
-      path [File.join(android_home, 'tools/bin')]
       user node['android-sdk']['owner']
       group node['android-sdk']['group']
       # TODO: use --force or not?


### PR DESCRIPTION
The Chef::Resource::Script#path property has been removed in Chef 13.